### PR TITLE
feat: cross-compile generic-account-api for Scala 2.12 + 2.13, migrat…

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,12 +8,12 @@ name: Build
 on:
   workflow_dispatch:
   push:
-    branches: 
+    branches:
       - '!main'
 #      - '*'         # matches every branch that doesn't contain a '/'
 #      - '*/*'       # matches every branch containing a single '/'
 #      - '**'        # matches every branch
-#      - '!main'     # excludes main  
+#      - '!main'     # excludes main
   pull_request:
     branches:
       - '**'
@@ -23,27 +23,33 @@ permissions:
 
 jobs:
   test:
-    runs-on: self-hosted
-#    runs-on: ubuntu-latest
-    env:
-      # define Java options for both official sbt and sbt-extras
-      JAVA_OPTS: -Xms2048M -Xmx2048M -Xss6M -XX:ReservedCodeCacheSize=256M -Dfile.encoding=UTF-8
-      JVM_OPTS:  -Xms2048M -Xmx2048M -Xss6M -XX:ReservedCodeCacheSize=256M -Dfile.encoding=UTF-8
+#    runs-on: self-hosted
+    runs-on: ubuntu-latest
     steps:
+    - name: Env
+      run: |
+        echo "JFROG_USER=${{ secrets.JFROG_USER }}" >>  $GITHUB_ENV
+        echo "JFROG_PASSWORD=${{ secrets.JFROG_PASSWORD }}" >>  $GITHUB_ENV
+        echo "GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}" >>  $GITHUB_ENV
+        echo "CODECOV_TOKEN=${{ secrets.CODECOV_TOKEN }}" >>  $GITHUB_ENV
     - name: Checkout
-      uses: actions/checkout@v3
-    - name: Set up JDK 8
-      uses: actions/setup-java@v3
+      uses: actions/checkout@v4
+    - name: Set up JDK 17
+      uses: actions/setup-java@v4
       with:
-        java-version: '8'
+        java-version: '17'
         distribution: 'temurin'
 #        cache: 'sbt'
+    - name: Setup sbt launcher
+      uses: sbt/setup-sbt@v1
+    - name: Cross Compile
+      run: SBT_OPTS="-Xss4M -Xms1g -Xmx4g -Dfile.encoding=UTF-8" sbt '+ Test/compile'
     - name: Run tests & Coverage Report
-      run: sbt coverage test coverageReport
+      run: SBT_OPTS="-Xss4M -Xms1g -Xmx4g -Dfile.encoding=UTF-8" sbt coverage test coverageReport
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v3
+      uses: codecov/codecov-action@v4
       with:
-        files: common/target/scala-2.12/coverage-report/cobertura.xml,core/target/scala-2.12/coverage-report/cobertura.xml,teskit/target/scala-2.12/coverage-report/cobertura.xml
+        files: common/target/scala-*/coverage-report/cobertura.xml,core/target/scala-*/coverage-report/cobertura.xml,testkit/target/scala-*/coverage-report/cobertura.xml
         flags: unittests
         fail_ci_if_error: true
         verbose: true
@@ -52,12 +58,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
-      - name: Set up JDK 8
-        uses: actions/setup-java@v3
+        uses: actions/checkout@v4
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
         with:
-          java-version: '8'
+          java-version: '17'
           distribution: 'temurin'
 #          cache: 'sbt'
+      - name: Setup sbt launcher
+        uses: sbt/setup-sbt@v1
       - name: Formatting
-        run: sbt scalafmtSbtCheck scalafmtCheck test:scalafmtCheck
+        run: sbt scalafmtSbtCheck scalafmtCheck Test/scalafmtCheck

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,32 +8,63 @@ name: Release
 on:
   workflow_dispatch:
   push:
-    branches: 
+    branches:
       - 'main'
 #      - '*'         # matches every branch that doesn't contain a '/'
 #      - '*/*'       # matches every branch containing a single '/'
 #      - '**'        # matches every branch
-#      - '!main'     # excludes main  
+#      - '!main'     # excludes main
 
 permissions:
   contents: read
 
 jobs:
   release:
-    runs-on: self-hosted
-#    runs-on: ubuntu-latest
-    env:
-      # define Java options for both official sbt and sbt-extras
-      JAVA_OPTS: -Xms2048M -Xmx2048M -Xss6M -XX:ReservedCodeCacheSize=256M -Dfile.encoding=UTF-8
-      JVM_OPTS:  -Xms2048M -Xmx2048M -Xss6M -XX:ReservedCodeCacheSize=256M -Dfile.encoding=UTF-8
+#    runs-on: self-hosted
+    runs-on: ubuntu-latest
     steps:
+    - name: Env
+      run: |
+        echo "JFROG_USER=${{ secrets.JFROG_USER }}" >>  $GITHUB_ENV
+        echo "JFROG_PASSWORD=${{ secrets.JFROG_PASSWORD }}" >>  $GITHUB_ENV
+        echo "GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}" >>  $GITHUB_ENV
+        echo "CODECOV_TOKEN=${{ secrets.CODECOV_TOKEN }}" >>  $GITHUB_ENV
     - name: Checkout
-      uses: actions/checkout@v3
-    - name: Set up JDK 8
-      uses: actions/setup-java@v3
+      uses: actions/checkout@v4
+    - name: Set up JDK 17
+      uses: actions/setup-java@v4
       with:
-        java-version: '8'
+        java-version: '17'
         distribution: 'temurin'
 #        cache: 'sbt'
-    - name: Run tests & publish
-      run: sbt test publish
+    - name: Setup sbt launcher
+      uses: sbt/setup-sbt@v1
+    - name: Cross Compile
+      run: SBT_OPTS="-Xss4M -Xms1g -Xmx4g -Dfile.encoding=UTF-8" sbt '+ Test/compile'
+    - name: Run tests & Coverage Report
+      run: SBT_OPTS="-Xss4M -Xms1g -Xmx4g -Dfile.encoding=UTF-8" sbt coverage test coverageReport coverageAggregate
+    - name: Upload coverage to Codecov
+      uses: codecov/codecov-action@v4
+      with:
+        files: common/target/scala-*/coverage-report/cobertura.xml,core/target/scala-*/coverage-report/cobertura.xml,testkit/target/scala-*/coverage-report/cobertura.xml
+        flags: unittests
+        fail_ci_if_error: false
+        verbose: true
+    - name: Publish
+      run: SBT_OPTS="-Xss4M -Xms1g -Xmx4g" sbt '+ publish'
+
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+#          cache: 'sbt'
+      - name: Setup sbt launcher
+        uses: sbt/setup-sbt@v1
+      - name: Formatting
+        run: sbt scalafmtSbtCheck scalafmtCheck Test/scalafmtCheck

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ sbt.json
 target
 .metals
 *.log
+actions-runner

--- a/api/build.sbt
+++ b/api/build.sbt
@@ -2,7 +2,7 @@ import com.typesafe.sbt.packager.docker._
 
 Compile / mainClass := Some("app.softnetwork.persistence.auth.api.BasicAccountEndpointsPostgresLauncher")
 
-dockerBaseImage := "openjdk:8"
+dockerBaseImage := "eclipse-temurin:17-jdk"
 
 dockerEntrypoint := Seq(s"${(Docker / defaultLinuxInstallLocation).value}/bin/entrypoint.sh")
 

--- a/build.sbt
+++ b/build.sbt
@@ -1,14 +1,28 @@
+lazy val scala212 = "2.12.20"
+lazy val scala213 = "2.13.16"
+lazy val javacCompilerVersion = "17"
+lazy val scalacCompilerOptions = Seq("-deprecation", "-feature")
+
+lazy val moduleSettings = Seq(
+  crossScalaVersions := Seq(scala212, scala213),
+  scalacOptions ++= {
+    CrossVersion.partialVersion(scalaVersion.value) match {
+      case Some((2, 12)) => scalacCompilerOptions
+      case Some((2, 13)) => scalacCompilerOptions :+ s"-release:$javacCompilerVersion"
+      case _             => Seq.empty
+    }
+  }
+)
+
 ThisBuild / organization := "app.softnetwork"
 
 name := "account"
 
-ThisBuild / version := "0.7.4"
+ThisBuild / version := "0.8.0"
 
-ThisBuild / scalaVersion := "2.12.18"
+ThisBuild / scalaVersion := scala212
 
-ThisBuild / scalacOptions ++= Seq("-deprecation", "-feature", "-target:jvm-1.8")
-
-ThisBuild / javacOptions ++= Seq("-source", "1.8", "-target", "1.8", "-Xlint")
+ThisBuild / javacOptions ++= Seq("-source", javacCompilerVersion, "-target", javacCompilerVersion, "-Xlint")
 
 ThisBuild / resolvers ++= Seq(
   "Softnetwork Server" at "https://softnetwork.jfrog.io/artifactory/releases/",
@@ -25,19 +39,49 @@ val scalatest = Seq(
 
 ThisBuild / libraryDependencies ++= Seq(
   "com.thesamet.scalapb" %% "scalapb-runtime" % scalapb.compiler.Version.scalapbVersion % "protobuf",
-  "org.scala-lang.modules" %% "scala-parser-combinators" % "1.1.1"
+  "org.scala-lang.modules" %% "scala-parser-combinators" % "1.1.2",
+  "org.scala-lang.modules" %% "scala-collection-compat" % "2.11.0",
+  "org.slf4j" % "slf4j-api" % Versions.slf4j,
+  "ch.qos.logback" % "logback-classic" % Versions.logback
 ) ++ scalatest
+
+ThisBuild / libraryDependencySchemes += "org.scala-lang.modules" %% "scala-xml" % VersionScheme.Always
+
+ThisBuild / javaOptions ++= Seq(
+  "--add-opens=java.base/java.util=ALL-UNNAMED",
+  "--add-opens=java.base/java.util.concurrent=ALL-UNNAMED",
+  "--add-opens=java.base/java.lang=ALL-UNNAMED",
+  "--add-opens=java.base/java.lang.invoke=ALL-UNNAMED",
+  "--add-opens=java.base/java.math=ALL-UNNAMED",
+  "--add-opens=java.base/java.io=ALL-UNNAMED",
+  "--add-opens=java.base/java.net=ALL-UNNAMED",
+  "--add-opens=java.base/java.nio=ALL-UNNAMED",
+  "--add-opens=java.base/java.text=ALL-UNNAMED",
+  "--add-opens=java.base/java.time=ALL-UNNAMED",
+  "--add-opens=java.base/sun.nio.ch=ALL-UNNAMED"
+)
+
+ThisBuild / Test / fork := true
+
+ThisBuild / Test / javaOptions ++= (ThisBuild / javaOptions).value
 
 Test / parallelExecution := false
 
 lazy val common = project.in(file("common"))
   .configs(IntegrationTest)
-  .settings(Defaults.itSettings)
+  .settings(
+    Defaults.itSettings,
+    moduleSettings
+  )
   .enablePlugins(AkkaGrpcPlugin)
 
 lazy val core = project.in(file("core"))
   .configs(IntegrationTest)
-  .settings(Defaults.itSettings, app.softnetwork.Info.infoSettings)
+  .settings(
+    Defaults.itSettings,
+    app.softnetwork.Info.infoSettings,
+    moduleSettings
+  )
   .enablePlugins(BuildInfoPlugin)
   .dependsOn(
     common % "compile->compile;test->test;it->it"
@@ -45,14 +89,20 @@ lazy val core = project.in(file("core"))
 
 lazy val testkit = project.in(file("testkit"))
   .configs(IntegrationTest)
-  .settings(Defaults.itSettings)
+  .settings(
+    Defaults.itSettings,
+    moduleSettings
+  )
   .dependsOn(
     core % "compile->compile;test->test;it->it"
   )
 
 lazy val api = project.in(file("api"))
   .configs(IntegrationTest)
-  .settings(Defaults.itSettings)
+  .settings(
+    Defaults.itSettings,
+    moduleSettings
+  )
   .enablePlugins(DockerComposePlugin, DockerPlugin, JavaAppPackaging)
   .dependsOn(
     core % "compile->compile;test->test;it->it"
@@ -61,4 +111,7 @@ lazy val api = project.in(file("api"))
 lazy val root = project.in(file("."))
   .aggregate(common, core, testkit, api)
   .configs(IntegrationTest)
-  .settings(Defaults.itSettings)
+  .settings(
+    Defaults.itSettings,
+    crossScalaVersions := Nil
+  )

--- a/common/build.sbt
+++ b/common/build.sbt
@@ -16,7 +16,7 @@ libraryDependencies ++= Seq(
   "app.softnetwork.notification" %% "notification-common" % Versions.notification,
   "app.softnetwork.notification" %% "notification-common" % Versions.notification % "protobuf",
   "app.softnetwork.api" %% "generic-server-api" % Versions.genericPersistence,
-  "app.softnetwork.protobuf" %% "scalapb-extensions" % "0.1.7"
+  "app.softnetwork.protobuf" %% "scalapb-extensions" % "0.2.0"
 )
 
 Compile / unmanagedResourceDirectories += baseDirectory.value / "src/main/protobuf"

--- a/common/src/main/resources/reference.conf
+++ b/common/src/main/resources/reference.conf
@@ -2,11 +2,13 @@ notification {
   push {
     clientId = "auth"
     clientId = ${?AUTH_PUSH_CLIENT_ID}
+    client-id = ${notification.push.clientId}
   }
 
   sms {
     clientId = "auth"
     clientId = ${?AUTH_SMS_CLIENT_ID}
+    client-id = ${notification.sms.clientId}
     name = "nobody"
     name = ${?NOTIFICATION_SMS_NAME}
   }
@@ -16,13 +18,16 @@ notification {
 auth {
   baseUrl = "http://localhost/api"
   baseUrl = ${?AUTH_BASE_URL}
+  base-url = ${auth.baseUrl}
 
   realm = "Realm"
 
   resetPasswordUrl = "http://localhost/reset_password.html"
   resetPasswordUrl = ${?AUTH_RESET_PASSWORD_URL}
+  reset-password-url = ${auth.resetPasswordUrl}
 
   regenerationOfThePasswordResetToken = true
+  regeneration-of-the-password-reset-token = ${auth.regenerationOfThePasswordResetToken}
 
   akka-node-role = accounts
 
@@ -31,6 +36,7 @@ auth {
     token {
       expirationTime = 1440
       expirationTime = ${?AUTH_ACTIVATION_TOKEN_EXPIRATION_TIME}
+      expiration-time = ${auth.activation.token.expirationTime}
     }
   }
 
@@ -41,10 +47,12 @@ auth {
 
       size           = ${?AUTH_VERIFICATION_CODE_SIZE}
       expirationTime = ${?AUTH_VERIFICATION_CODE_EXPIRATION_TIME}
+      expiration-time = ${auth.verification.code.expirationTime}
     }
     token {
       expirationTime = 10
       expirationTime = ${?AUTH_VERIFICATION_TOKEN_EXPIRATION_TIME}
+      expiration-time = ${auth.verification.token.expirationTime}
     }
     gsm {
       enabled = true
@@ -65,12 +73,15 @@ auth {
     upperCaseCharacter{
       size = 1
     }
+    upper-case-character = ${auth.password.upperCaseCharacter}
     lowerCaseCharacter{
       size = 1
     }
+    lower-case-character = ${auth.password.lowerCaseCharacter}
     numberCharacter{
       size = 1
     }
+    number-character = ${auth.password.numberCharacter}
   }
 
   anonymous {
@@ -78,6 +89,7 @@ auth {
   }
 
   maxLoginFailures = 4
+  max-login-failures = ${auth.maxLoginFailures}
 
   notifications {
     activation = "Activation"
@@ -118,16 +130,19 @@ auth {
     authorization-code {
       expirationTime = 5
       expirationTime = ${?AUTH_AUTHORIZATION_CODE_EXPIRATION_TIME}
+      expiration-time = ${auth.oauth.authorization-code.expirationTime}
     }
 
     access-token {
       expirationTime = 30
       expirationTime = ${?AUTH_ACCESS_TOKEN_EXPIRATION_TIME}
+      expiration-time = ${auth.oauth.access-token.expirationTime}
     }
 
     refresh-token {
       expirationTime = 525600 // 60 * 24 * 365
       expirationTime = ${?AUTH_REFRESH_TOKEN_EXPIRATION_TIME}
+      expiration-time = ${auth.oauth.refresh-token.expirationTime}
     }
 
     providers {

--- a/common/src/main/scala/app/softnetwork/account/config/AccountSettings.scala
+++ b/common/src/main/scala/app/softnetwork/account/config/AccountSettings.scala
@@ -4,7 +4,7 @@ package app.softnetwork.account.config
   */
 import com.typesafe.config.{Config, ConfigFactory}
 import com.typesafe.scalalogging.StrictLogging
-import configs.Configs
+import configs.ConfigReader
 import Password._
 
 object AccountSettings extends StrictLogging {
@@ -49,7 +49,7 @@ object AccountSettings extends StrictLogging {
   val MaxLoginFailures: Int = config.getInt("auth.maxLoginFailures")
 
   def passwordRules(config: Config = config): PasswordRules =
-    Configs[PasswordRules].get(config, "auth.password").toEither match {
+    ConfigReader[PasswordRules].read(config, "auth.password").toEither match {
       case Left(configError) =>
         logger.error(s"Something went wrong with the provided arguments $configError")
         PasswordRules()
@@ -57,15 +57,15 @@ object AccountSettings extends StrictLogging {
     }
 
   lazy val NotificationsConfig: Notifications.Config =
-    Configs[Notifications.Config].get(config, "auth.notifications").toEither match {
+    ConfigReader[Notifications.Config].read(config, "auth.notifications").toEither match {
       case Left(configError) =>
         logger.error(s"Something went wrong with the provided arguments $configError")
         throw configError.configException
       case Right(notificationsConfig) => notificationsConfig
     }
 
-  lazy val AdministratorsConfig: Administrators.Config = Configs[Administrators.Config]
-    .get(
+  lazy val AdministratorsConfig: Administrators.Config = ConfigReader[Administrators.Config]
+    .read(
       config,
       "auth.admin"
     )
@@ -83,7 +83,7 @@ object AccountSettings extends StrictLogging {
   val AnonymousPassword: String = config.getString("auth.anonymous.password")
 
   lazy val OAuthSettings: OAuthConfig =
-    Configs[OAuthConfig].get(config, "auth.oauth").toEither match {
+    ConfigReader[OAuthConfig].read(config, "auth.oauth").toEither match {
       case Left(configError) =>
         logger.error(s"Something went wrong with the provided arguments $configError")
         throw configError.configException

--- a/common/src/main/scala/app/softnetwork/account/config/Password.scala
+++ b/common/src/main/scala/app/softnetwork/account/config/Password.scala
@@ -2,13 +2,29 @@ package app.softnetwork.account.config
 
 import java.util.regex.Matcher
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 
+import configs.ConfigReader
 import org.passay._
 
 /** Created by smanciot on 11/04/2018.
   */
 object Password {
+
+  implicit val upperCaseCharacterReader: ConfigReader[UpperCaseCharacter] =
+    ConfigReader.fromTry(_.getConfig(_).getInt("size")).map(new UpperCaseCharacter(_))
+
+  implicit val lowerCaseCharacterReader: ConfigReader[LowerCaseCharacter] =
+    ConfigReader.fromTry(_.getConfig(_).getInt("size")).map(new LowerCaseCharacter(_))
+
+  implicit val numberCharacterReader: ConfigReader[NumberCharacter] =
+    ConfigReader.fromTry(_.getConfig(_).getInt("size")).map(new NumberCharacter(_))
+
+  implicit val specialCharacterReader: ConfigReader[SpecialCharacter] =
+    ConfigReader.fromTry(_.getConfig(_).getInt("size")).map(new SpecialCharacter(_))
+
+  implicit val whitespaceReader: ConfigReader[Whitespace] =
+    ConfigReader.fromTry((c, p) => { c.getConfig(p); Whitespace() })
 
   sealed trait PasswordRule {
     def rule: Rule
@@ -47,7 +63,7 @@ object Password {
       if (result.isValid)
         Right(true)
       else
-        Left(result.getDetails.asScala.map(_.getErrorCode))
+        Left(result.getDetails.asScala.map(_.getErrorCode).toSeq)
     }
 
     def generatePassword(size: Int): String = {

--- a/common/src/main/scala/app/softnetwork/account/spi/OAuth2Service.scala
+++ b/common/src/main/scala/app/softnetwork/account/spi/OAuth2Service.scala
@@ -47,7 +47,7 @@ trait OAuth2Service {
     service.signRequest(accessToken, request)
 
   def getAccessToken(code: String, extraParameters: Map[String, String]): OAuth2AccessToken = {
-    import scala.collection.JavaConverters._
+    import scala.jdk.CollectionConverters._
     service.getAccessToken(
       AccessTokenRequestParams.create(code).setExtraParameters(extraParameters.asJava)
     )
@@ -72,6 +72,7 @@ trait OAuth2Service {
     jsonMapper
       .readValue(execute(request).getBody, classOf[Map[String, Any]])
       .mapValues(_.toString)
+      .toMap
   }
 
   def extractData(data: Map[String, String]): OAuthData = OAuthData(networkName, data)

--- a/core/src/main/scala/app/softnetwork/account/persistence/typed/AccountBehavior.scala
+++ b/core/src/main/scala/app/softnetwork/account/persistence/typed/AccountBehavior.scala
@@ -1379,5 +1379,5 @@ trait AccountBehavior[T <: Account with AccountDecorator, P <: Profile]
   }
 
   private[this] def lookupAccount(key: String)(implicit system: ActorSystem[_]): Option[String] =
-    accountKeyDao.lookupAccount(key) complete ()
+    accountKeyDao.lookupAccount(key).complete()
 }

--- a/core/src/main/scala/app/softnetwork/account/service/AccountServiceEndpoints.scala
+++ b/core/src/main/scala/app/softnetwork/account/service/AccountServiceEndpoints.scala
@@ -98,7 +98,7 @@ trait AccountServiceEndpoints[SU, SD <: SessionData with SessionDataDecorator[SD
                     case _                                                         => generateUUID()
                   }
 
-                run(uuid, SignUpAnonymous) complete () match {
+                run(uuid, SignUpAnonymous).complete() match {
 
                   case Success(value) =>
                     value match {
@@ -164,7 +164,7 @@ trait AccountServiceEndpoints[SU, SD <: SessionData with SessionDataDecorator[SD
                 run(
                   uuid,
                   signUp
-                ) complete () match {
+                ).complete() match {
                   case Success(value) =>
                     value match {
 
@@ -295,7 +295,7 @@ trait AccountServiceEndpoints[SU, SD <: SessionData with SessionDataDecorator[SD
                           None
                       )
                     )
-                ) complete () match {
+                ).complete() match {
 
                   case Success(value) =>
                     value match {

--- a/project/Versions.scala
+++ b/project/Versions.scala
@@ -1,10 +1,14 @@
 object Versions {
 
-  val genericPersistence = "0.7.3"
+  val genericPersistence = "0.8.1"
 
-  val notification = "0.8.2"
+  val notification = "0.9.0"
 
-  val scheduler = "0.7.3"
+  val scheduler = "0.8.0"
+
+  val slf4j = "2.0.7"
+
+  val logback = "1.4.14"
 
   val scalatest = "3.2.16"
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -7,11 +7,11 @@ resolvers ++= Seq(
   "Softnetwork releases" at "https://softnetwork.jfrog.io/artifactory/releases/"
 )
 
-addSbtPlugin("app.softnetwork.sbt-softnetwork" % "sbt-softnetwork-git" % "0.1.7")
+addSbtPlugin("app.softnetwork.sbt-softnetwork" % "sbt-softnetwork-git" % "0.2.0")
 
-addSbtPlugin("app.softnetwork.sbt-softnetwork" % "sbt-softnetwork-info" % "0.1.7")
+addSbtPlugin("app.softnetwork.sbt-softnetwork" % "sbt-softnetwork-info" % "0.2.0")
 
-addSbtPlugin("app.softnetwork.sbt-softnetwork" % "sbt-softnetwork-publish" % "0.1.7")
+addSbtPlugin("app.softnetwork.sbt-softnetwork" % "sbt-softnetwork-publish" % "0.2.0")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.3.10")
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -21,4 +21,4 @@ addDependencyTreePlugin
 
 //addSbtPlugin("com.typesafe.sbt" % "sbt-multi-jvm" % "0.4.0")
 
-addSbtPlugin("org.scoverage" % "sbt-scoverage" % "2.0.8")
+addSbtPlugin("org.scoverage" % "sbt-scoverage" % "2.3.0")

--- a/testkit/src/main/resources/reference.conf
+++ b/testkit/src/main/resources/reference.conf
@@ -1,8 +1,11 @@
 notification{
   mail {
     sslEnabled             = false
+    ssl-enabled            = ${notification.mail.sslEnabled}
     sslCheckServerIdentity = false
+    ssl-check-server-identity = ${notification.mail.sslCheckServerIdentity}
     startTLSEnabled        = false
+    start-tls-enabled      = ${notification.mail.startTLSEnabled}
   }
 
   push {
@@ -20,6 +23,7 @@ notification{
       fcm {
         databaseUrl        = ""
         databaseUrl        = ${?NOTIFICATION_PUSH_FCM_DATABASE_URL}
+        database-url       = ${notification.push.mock.fcm.databaseUrl}
         google-credentials = ""
         google-credentials = ${?GOOGLE_APPLICATION_CREDENTIALS}
       }

--- a/testkit/src/main/scala/app/softnetwork/account/scalatest/AccountRouteTestKit.scala
+++ b/testkit/src/main/scala/app/softnetwork/account/scalatest/AccountRouteTestKit.scala
@@ -24,13 +24,13 @@ trait AccountRouteTestKit[
 
   override implicit lazy val ts: ActorSystem[_] = typedSystem()
 
-/*
+  /*
   override def beforeAll(): Unit = {
     super.beforeAll()
     // pre load routes
     apiRoutes(typedSystem())
   }
-*/
+   */
 
   def signUp(
     login: String,


### PR DESCRIPTION
…e to Java 17

- Version 0.7.4 → 0.8.0 with crossScalaVersions per-module (moduleSettings pattern)
- Java target 1.8 → 17 with --add-opens JVM flags for forked tests
- Upgraded dependencies: generic-persistence 0.8.1, notification 0.9.0, scheduler 0.8.0, sbt-softnetwork 0.2.0, scalapb-extensions 0.2.0, slf4j 2.0.7, logback 1.4.14
- Scala 2.13 compat: JavaConverters → jdk.CollectionConverters, Configs → ConfigReader, postfix complete() → dotted, .mapValues().toMap, .asScala.toSeq
- Added ConfigReader implicits for non-case-class Password types
- Added kebab-case aliases in reference.conf for configs 0.6.x hyphenSeparated naming
- CI/CD: ubuntu-latest, JDK 17, cross-compile step, upgraded GitHub Actions (v4), cross-publish in release, Docker base eclipse-temurin:17-jdk

Closed Issue #5