### PR TITLE
feat(account): configurable activation URL + AUTH_ACTIVATION_ENABLED …

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -18,7 +18,7 @@ ThisBuild / organization := "app.softnetwork"
 
 name := "account"
 
-ThisBuild / version := "0.8.4"
+ThisBuild / version := "0.8.5"
 
 ThisBuild / scalaVersion := scala212
 

--- a/common/src/main/resources/reference.conf
+++ b/common/src/main/resources/reference.conf
@@ -26,6 +26,14 @@ auth {
   resetPasswordUrl = ${?AUTH_RESET_PASSWORD_URL}
   reset-password-url = ${auth.resetPasswordUrl}
 
+  # Activation link emitted in the account-activation email. `{token}` is replaced with the
+  # activation token. Default reproduces the historical `${baseUrl}/${path}/activate/<token>`
+  # (backend, path-style). Override (e.g. AUTH_ACTIVATION_URL=https://app.example.com/activate?token={token})
+  # for SPA frontends that expect a query-style token on a dedicated activation route.
+  activationUrl = ${auth.baseUrl}"/"${auth.path}"/activate/{token}"
+  activationUrl = ${?AUTH_ACTIVATION_URL}
+  activation-url = ${auth.activationUrl}
+
   regenerationOfThePasswordResetToken = true
   regeneration-of-the-password-reset-token = ${auth.regenerationOfThePasswordResetToken}
 
@@ -33,6 +41,7 @@ auth {
 
   activation {
     enabled = true
+    enabled = ${?AUTH_ACTIVATION_ENABLED}
     token {
       expirationTime = 1440
       expirationTime = ${?AUTH_ACTIVATION_TOKEN_EXPIRATION_TIME}

--- a/common/src/main/scala/app/softnetwork/account/config/AccountSettings.scala
+++ b/common/src/main/scala/app/softnetwork/account/config/AccountSettings.scala
@@ -21,6 +21,11 @@ object AccountSettings extends StrictLogging {
 
   val ResetPasswordUrl: String = config.getString("auth.resetPasswordUrl")
 
+  /** Activation link template emitted in the activation email. Contains a `{token}` placeholder
+    * replaced with the activation token. Defaults to `${baseUrl}/${path}/activate/{token}`.
+    */
+  val ActivationUrl: String = config.getString("auth.activationUrl")
+
   val RegenerationOfThePasswordResetToken: Boolean =
     config.getBoolean("auth.regenerationOfThePasswordResetToken")
 

--- a/core/src/main/scala/app/softnetwork/account/persistence/typed/AccountNotifications.scala
+++ b/core/src/main/scala/app/softnetwork/account/persistence/typed/AccountNotifications.scala
@@ -208,7 +208,7 @@ trait AccountNotifications[T <: Account] extends Completion {
           case Some(s) => StringEscapeUtils.escapeHtml4(s.firstName)
           case _       => "customer"
         }),
-        "activationUrl" -> s"$BaseUrl/$Path/activate/${activationToken.token}",
+        "activationUrl" -> ActivationUrl.replace("{token}", activationToken.token),
         "signature"     -> NotificationsConfig.signature
       )
     )


### PR DESCRIPTION
…env toggle

Closes #9.

The activation email link was hardcoded to `${baseUrl}/${path}/activate/<token>` (backend, path-style), so it couldn't be pointed at an SPA frontend that expects a query-style token on a dedicated route (e.g. /activate?token=<token>).

- Add `auth.activationUrl` (mirrors auth.resetPasswordUrl) with a `{token}` placeholder and `AUTH_ACTIVATION_URL` override. Default reproduces the historical URL exactly, so existing consumers are unaffected. AccountNotifications now renders ActivationUrl.replace("{token}", token).
- Allow toggling activation via env: `auth.activation.enabled = ${?AUTH_ACTIVATION_ENABLED}` (AccountSettings.ActivationEnabled already reads auth.activation.enabled).

Both changes are additive and default to current behavior. Version 0.8.4 -> 0.8.5.