### PR TITLE
Stamp the account e-mail into the session at sign-in

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -18,7 +18,7 @@ ThisBuild / organization := "app.softnetwork"
 
 name := "account"
 
-ThisBuild / version := "0.8.7"
+ThisBuild / version := "0.8.8"
 
 ThisBuild / scalaVersion := scala212
 

--- a/common/src/main/scala/app/softnetwork/account/config/AccountSettings.scala
+++ b/common/src/main/scala/app/softnetwork/account/config/AccountSettings.scala
@@ -15,6 +15,20 @@ object AccountSettings extends StrictLogging {
 
   val Realm: String = config.getString("auth.realm")
 
+  /** Session key holding the account's e-mail, stamped at sign-in by every authentication path.
+    *
+    * Downstream services derive trust decisions from the e-mail DOMAIN — the licence server keys
+    * its one-evaluation-per-organisation rule and its free-mail gate on it. Their only other source
+    * is an organisation contact address the requester can edit, i.e. forge. Putting the address
+    * here places it behind the session's HMAC, which is the same trust the `admin` flag already
+    * relies on for authorization.
+    *
+    * Not a config value: it is a wire contract with those readers, so it must not be re-mappable
+    * per deployment. Absent for an account registered by phone (`Account.email` is an `Option`) —
+    * readers must handle that rather than assume presence.
+    */
+  val SessionEmailKey: String = "email"
+
   val Path: String = config.getString("auth.path")
 
   val BaseUrl: String = config.getString("auth.baseUrl")

--- a/core/src/main/scala/app/softnetwork/account/service/AccountService.scala
+++ b/core/src/main/scala/app/softnetwork/account/service/AccountService.scala
@@ -182,6 +182,10 @@ trait AccountService[PV <: ProfileView, DV <: AccountDetailsView, AV <: AccountV
               session += (session.profileKey, profile.name)
             case _ =>
           }
+          account.email match {
+            case Some(email) => session += (AccountSettings.SessionEmailKey, email)
+            case _           =>
+          }
           setSession(sc, st, session) {
             // create a new anti csrf token
             setNewCsrfToken(checkHeader) {
@@ -223,6 +227,10 @@ trait AccountService[PV <: ProfileView, DV <: AccountDetailsView, AV <: AccountV
                 case Some(profile) =>
                   session += (session.profileKey, profile.name)
                 case _ =>
+              }
+              account.email match {
+                case Some(email) => session += (AccountSettings.SessionEmailKey, email)
+                case _           =>
               }
               setSession(sc, st, session) {
                 // create a new anti csrf token

--- a/core/src/main/scala/app/softnetwork/account/service/AccountServiceEndpoints.scala
+++ b/core/src/main/scala/app/softnetwork/account/service/AccountServiceEndpoints.scala
@@ -248,6 +248,10 @@ trait AccountServiceEndpoints[SU, SD <: SessionData with SessionDataDecorator[SD
                     session += (session.profileKey, profile.name)
                   case _ =>
                 }
+                account.email match {
+                  case Some(email) => session += (AccountSettings.SessionEmailKey, email)
+                  case _           =>
+                }
                 Right((account.view.asInstanceOf[AV], Some(session)))
               case other => Left(resultToApiError(other))
             }
@@ -312,6 +316,10 @@ trait AccountServiceEndpoints[SU, SD <: SessionData with SessionDataDecorator[SD
                           case Some(profile) =>
                             session += (session.profileKey, profile.name)
                           case _ =>
+                        }
+                        account.email match {
+                          case Some(email) => session += (AccountSettings.SessionEmailKey, email)
+                          case _           =>
                         }
                         Right(
                           (

--- a/core/src/main/scala/app/softnetwork/account/service/OAuthService.scala
+++ b/core/src/main/scala/app/softnetwork/account/service/OAuthService.scala
@@ -165,6 +165,10 @@ trait OAuthService[SD <: SessionData with SessionDataDecorator[SD]]
               session += (session.profileKey, profile.name)
             case _ =>
           }
+          account.email match {
+            case Some(email) => session += (AccountSettings.SessionEmailKey, email)
+            case _           =>
+          }
           setSession(sc, st, session) {
             // create a new anti csrf token
             setNewCsrfToken(checkHeader) {

--- a/core/src/main/scala/app/softnetwork/account/service/OAuthServiceEndpoints.scala
+++ b/core/src/main/scala/app/softnetwork/account/service/OAuthServiceEndpoints.scala
@@ -222,6 +222,10 @@ trait OAuthServiceEndpoints[SD <: SessionData with SessionDataDecorator[SD]]
                     session += (session.profileKey, profile.name)
                   case _ =>
                 }
+                account.email match {
+                  case Some(email) => session += (AccountSettings.SessionEmailKey, email)
+                  case _           =>
+                }
                 Right(
                   account.details
                     .map(d => Me(d.firstName, d.lastName, d.email))

--- a/testkit/src/main/scala/app/softnetwork/account/scalatest/AccountRouteSpec.scala
+++ b/testkit/src/main/scala/app/softnetwork/account/scalatest/AccountRouteSpec.scala
@@ -313,6 +313,24 @@ trait AccountRouteSpec[
         responseAs[AV].status shouldBe AccountStatus.Active
       }
     }
+    // Downstream services key trust decisions on the DOMAIN of this address — the licence server
+    // decides one-evaluation-per-organisation and its free-mail gate on it. Their only other source
+    // is an organisation contact the requester can edit, i.e. forge, so the stamp is a contract
+    // rather than a convenience. It is asserted at the SESSION because an authentication path that
+    // forgets it degrades silently: the reader just falls back.
+    // (The e-mail account is activated by "work with matching email and password" above.)
+    "stamp the account e-mail into the session" in {
+      // No trailing signOut(): `signIn` opens with one, and calling it twice leaves stale
+      // headers that make the NEXT sign-in 403.
+      signIn(email, password)
+      extractSession().flatMap(_.get(AccountSettings.SessionEmailKey)) shouldBe Some(email)
+    }
+    // `Account.email` is an Option — an account registered by phone has none. The key must then be
+    // ABSENT rather than empty, so a reader can tell "no address" from "an address we lost".
+    "leave the e-mail absent for an account that has none" in {
+      signIn(gsm, password)
+      extractSession().flatMap(_.get(AccountSettings.SessionEmailKey)) shouldBe None
+    }
     "fail with unknown username" in {
       Post(
         s"/$RootPath/${AccountSettings.Path}/login",


### PR DESCRIPTION
## Why

A session tells a downstream reader **who** the account is (`id`, `admin`, `profile`, `anonymous`, `client_id`) but not **what address it authenticated with**. Any service that needs to make a trust decision on the account's e-mail *domain* therefore has to fall back on a profile or organisation contact field the user can edit — i.e. forge.

The licence server is the immediate consumer. It decides *one evaluation per organisation* and refuses free-mail domains on that domain, and today both rules are bypassable: edit the organisation contact, get a new domain. It can also be pointed at a domain the requester does not control.

## What

Stamp the account e-mail into the session at sign-in, putting it behind the session's HMAC — the same trust `session.admin` already carries for an authorization decision.

**No new session API.** `SessionDataDecorator` already exposes a generic `+(kv)`, and every one of these sites already uses it one line below to stamp the profile:

```scala
account.currentProfile match {
  case Some(profile) => session += (session.profileKey, profile.name)
  case _             =>
}
account.email match {                                            // new
  case Some(email) => session += (AccountSettings.SessionEmailKey, email)
  case _           =>
}
```

**All six authentication paths**, as one change — `AccountServiceEndpoints` ×2, `AccountService` ×2, `OAuthServiceEndpoints`, `OAuthService`. A missed path would not fail loudly: the reader would fall back to the editable address and be quietly wrong.

**The key is a constant in `AccountSettings`, deliberately not a config value.** It is a wire contract with those readers, so it must not be re-mappable per deployment.

**`Account.email` is an `Option`** — an account registered by phone has none — so the key is **absent** rather than empty, letting a reader distinguish *no address* from *an address we lost*.

## Tests

Added to `AccountRouteSpec`, so they run across all **eight** concrete variants — akka-http routes **and** tapir endpoints, cookie **and** header, one-off **and** refreshable:

- the e-mail is present in the session after sign-in;
- it is **absent** for a gsm-only account. That second one is not decoration: it is what rules out an unconditional `getOrElse("")` stamp, which would otherwise pass the first test.

`testkit/test` — **480 passed**. Cross-compiles 2.12 + 2.13; `scalafmtCheck` / `test:scalafmtCheck` clean.

One trap worth recording: `signIn` opens with its own `signOut()`, so a trailing `signOut()` in a test leaves stale headers and the *next* sign-in 403s.

## Release

`ThisBuild / version := "0.8.8"`.

Downstream train: **generic-account-api 0.8.8 → softpayment → softclient4es-license-server**, which has no direct pin and resolves this transitively via `Versions.softPayment`.

The licence-server read side is already written and is **deliberately inert until this publishes**: `session.get(...)` compiles against 0.8.7, returns `None`, and falls back to the old source with a WARN. So there is no dependency-order trap and nothing breaks while the train runs — behaviour flips when this lands.

Design recorded in `adr-evaluation-trusted-domain-source` (elasticsql planning artifacts).
